### PR TITLE
Update to Hero attacks

### DIFF
--- a/DocumentationDocNet/Fights.md
+++ b/DocumentationDocNet/Fights.md
@@ -101,6 +101,14 @@ Max one free attack per turn, used at any time during the hero’s activation.
 
 Use the weapon's Combat value instead of the hero's Combat.
 
+### Dual Wielding
+
+A Hero can equip two Single-Handed ranged weapons and use both for a ranged attack at the cost of not being able to score any Critical Hits with either weapon.
+In addition the weapon considered their Off-Hand weapon needs to roll one number higher then normal when hitting. As an example if a Hero has a To Hit Range 3+ they need to roll 4+ instead for the Off-Hand weapon.
+It is recommended that you use two colors of dice for this roll.
+
+These penalties do not apply to melee dual wielding.
+
 ### Dynamite / Bomb
 
 See [Dynamite/Bomb](SideBag.htm) token.

--- a/DocumentationDocNet/Fights.md
+++ b/DocumentationDocNet/Fights.md
@@ -93,7 +93,7 @@ Evenly distributed random targets if there are more heroes than enemies of that 
 
 * Min target number: 2+
 * Max target number: 6+ (unless rolling D8 for attacks)
-* Max dice: 6 Combat or 6 Shots in a single attack. [Official Rule Change]
+* Max dice: 8 Combat or 8 Shots in a single attack. [Official Rule Change]
 
 ### Free Attacks
 


### PR DESCRIPTION
Updated the max number of dice roll and added the rules regarding dual wielding based on the latest rulebook that was released on the [Flying Frogs Website ](https://www.flyingfrog.net/shadowsofbrimstone/pdf/REV__SBCA_Rulebook_WEB.pdf).

Both changes can be found on page 33